### PR TITLE
Changing Platform Number for CHIP

### DIFF
--- a/gaugette/platform.py
+++ b/gaugette/platform.py
@@ -25,7 +25,7 @@ import re
 UNKNOWN          = 0
 RASPBERRY_PI     = 1
 BEAGLEBONE_BLACK = 2
-CHIP             = 5
+CHIP             = 3
 
 isBeagleBoneBlack = False
 isRaspberryPi = False


### PR DESCRIPTION
Making the CHIP platform 3 due to there being no existing pull requests for other computers besides the RPi and BBB.
